### PR TITLE
socket.ioが接続できないバグが入ったのを修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 "use strict"
+var debug = require('debug')('tennis-score');
 var express = require('express');
 var path = require('path');
 var favicon = require('serve-favicon');
@@ -215,7 +216,7 @@ io.sockets.on('connection',function(socket){
           tennis.save();
           socket.broadcast.json.emit('player-update',data);
       });
-  });                    
+  });
   //changed pointtext
   socket.on('pointext-update',function(data){
       Tennis.findOne({_id:data._id},function(err,tennis){
@@ -223,7 +224,7 @@ io.sockets.on('connection',function(socket){
           tennis.pointext = data.pointext;
           tennis.save();
           socket.broadcast.json.emit('pointext-update',data);
-      }); 
+      });
   });
 });
 
@@ -252,4 +253,9 @@ app.use(function(err, req, res, next) {
     });
 });
 
+if(process.argv[1] == __filename){
+  server.listen(app.get('port'), function(){
+    console.log("Express server listening on port " + app.get('port'));
+  });
+}
 module.exports = app;

--- a/bin/www
+++ b/bin/www
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-var debug = require('debug')('tennis-score');
-var app = require('../app');
-
-app.set('port', process.env.PORT || 3000);
-
-var server = app.listen(app.get('port'), function() {
-  debug('Express server listening on port ' + server.address().port);
-});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node app.js"
   },
   "dependencies": {
     "express": "~4.9.0",


### PR DESCRIPTION
- node app.jsで実行した時はサーバーを起動する
- app.jsをライブラリとして読み込んだ時、サーバーを起動しないので、テストなどは可能
- bin/wwwからの起動を廃止
